### PR TITLE
fix: remove '../' part of video to assets folder

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,7 +1,7 @@
 <section class="box home" *yqni13Var="user$ | async as userData">
     <div class="home-wrapper">
         <video autoplay loop [muted]="'muted'">
-            <source src="../../assets/landingpage_long_compressed.mp4" type="video/mp4"/>
+            <source src="assets/landingpage_long_compressed.mp4" type="video/mp4"/>
             Your browser does not support the video file (mp4).
         </video>
         <div class="column introduction">


### PR DESCRIPTION
Remove '../' steps because assets folder is located forward in build.
>> "../../../assets/xyz" to "assets/xyz" path